### PR TITLE
Update engine to use include paths

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,20 +42,13 @@ GEM
       method_source (~> 0.8.1)
       slop (~> 3.4)
     rack (1.6.0)
-    rack-protection (1.5.3)
-      rack
     rack-test (0.6.3)
       rack (>= 1.0)
     rainbow (2.0.0)
     rake (10.4.2)
     ruby-progressbar (1.7.5)
-    sinatra (1.4.6)
-      rack (~> 1.4)
-      rack-protection (~> 1.4)
-      tilt (>= 1.3, < 3)
     slop (3.6.0)
     thread_safe (0.3.5)
-    tilt (2.0.1)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
 
@@ -71,4 +64,3 @@ DEPENDENCIES
   rack-test
   rake
   rubocop!
-  sinatra (~> 1.4.6)

--- a/lib/cc/engine/analyzable_files.rb
+++ b/lib/cc/engine/analyzable_files.rb
@@ -1,0 +1,34 @@
+module CC
+  module Engine
+    class AnalyzableFiles
+      def initialize(config)
+        @config = config
+      end
+
+      def all
+        @files ||= if @config["include_paths"]
+          build_files_with_inclusions(@config["include_paths"])
+        else
+          build_files_with_exclusions(@config["exclude_paths"] || [])
+        end
+      end
+
+      private
+
+      def build_files_with_inclusions(inclusions)
+        inclusions.map do |include_path|
+          if include_path =~ %r{/$}
+            Dir.glob("#{include_path}/**/*.rb")
+          else
+            include_path if include_path =~ /\.rb$/
+          end
+        end.flatten.compact
+      end
+
+      def build_files_with_exclusions(exclusions)
+        files = Dir.glob("**/*.rb")
+        files.reject { |f| exclusions.include?(f) }
+      end
+    end
+  end
+end

--- a/lib/cc/engine/rubymotion.rb
+++ b/lib/cc/engine/rubymotion.rb
@@ -63,11 +63,6 @@ module CC
         files.reject { |f| exclusions.include?(f) }
       end
 
-      def exclude?(path)
-        exclusions = @engine_config["exclude_paths"] || []
-        exclusions.include?(path)
-      end
-
       def rubocop_team
         RuboCop::Cop::Team.new(CC::RubymotionCops.all, rubocop_config)
       end

--- a/lib/cc/engine/rubymotion.rb
+++ b/lib/cc/engine/rubymotion.rb
@@ -1,5 +1,6 @@
 require 'rubocop'
 require 'cc/rubymotion_cops'
+require 'cc/engine/analyzable_files'
 require 'json'
 
 module CC
@@ -41,26 +42,7 @@ module CC
       private
 
       def files_to_analyze
-        if @engine_config["include_paths"]
-          build_files_with_inclusions(@engine_config["include_paths"])
-        else
-          build_files_with_exclusions(@engine_config["exclude_paths"] || [])
-        end
-      end
-
-      def build_files_with_inclusions(inclusions)
-        inclusions.map do |include_path|
-          if include_path =~ %r{/$}
-            Dir.glob("#{include_path}/**/*.rb")
-          else
-            include_path if include_path =~ /\.rb$/
-          end
-        end.flatten.compact
-      end
-
-      def build_files_with_exclusions(exclusions)
-        files = Dir.glob("**/*.rb")
-        files.reject { |f| exclusions.include?(f) }
+        AnalyzableFiles.new(@engine_config).all
       end
 
       def rubocop_team
@@ -70,7 +52,6 @@ module CC
       def rubocop_config
         @rubocop_config ||= RuboCop::Config.new({}, "")
       end
-
     end
   end
 end


### PR DESCRIPTION
As listed in [spec](https://github.com/codeclimate/spec/blob/master/SPEC.md#input) `excluded_paths` is now deprecated.
